### PR TITLE
fix(field_processing.py): Save `mc_params` as pickle object

### DIFF
--- a/element_calcium_imaging/field_processing.py
+++ b/element_calcium_imaging/field_processing.py
@@ -364,21 +364,19 @@ class FieldMotionCorrection(dj.Computed):
                     "cnmf_mc_output_file": cnmf_mc_output_file.relative_to(
                         processed_root_data_dir
                     ).as_posix(),
-                    "mc_results": mc_results,
                 }
+                pickle.dump(
+                    mc_results,
+                    output_dir
+                    / f"{key['subject']}_session{key['session']}_params{key['paramset_idx']}_field{key['field_idx']}_motion_correction_results.pkl",
+                )
                 return extra_dj_params
 
             extra_dj_params = _run_motion_correction()
             params["fnames"] = [
                 f.relative_to(processed_root_data_dir).as_posix() for f in file_paths
             ]
-            motion_correction_results = extra_dj_params.pop("mc_results")
             params["extra_dj_params"] = extra_dj_params
-            pickle.dump(
-                motion_correction_results,
-                output_dir
-                / f"{key['subject']}_session{key['session']}_params{key['paramset_idx']}_field{key['field_idx']}_motion_correction_results.pkl",
-            )
 
             if mc_indices is not None:
                 # store "indices" in params as tuple instead of the `slice` object

--- a/element_calcium_imaging/field_processing.py
+++ b/element_calcium_imaging/field_processing.py
@@ -372,8 +372,14 @@ class FieldMotionCorrection(dj.Computed):
             params["fnames"] = [
                 f.relative_to(processed_root_data_dir).as_posix() for f in file_paths
             ]
-            pickle.dump(extra_dj_params, output_dir / f"{key['subject']}_session{key['session']}_params{key['paramset_idx']}_field{key['field_idx']}_motion_correction_results.pkl")
-            
+            motion_correction_results = extra_dj_params.pop("mc_results")
+            params["extra_dj_params"] = extra_dj_params
+            pickle.dump(
+                motion_correction_results,
+                output_dir
+                / f"{key['subject']}_session{key['session']}_params{key['paramset_idx']}_field{key['field_idx']}_motion_correction_results.pkl",
+            )
+
             if mc_indices is not None:
                 # store "indices" in params as tuple instead of the `slice` object
                 params["motion"]["indices"] = mc_indices
@@ -399,7 +405,9 @@ class FieldMotionCorrection(dj.Computed):
                     "file_name": f.relative_to(output_dir.parent).as_posix(),
                     "file": f,
                 }
-                for f in output_dir.rglob(f"{key['subject']}_session{key['session']}_params{key['paramset_idx']}_field{key['field_idx']}_motion_correction_results.pkl")
+                for f in output_dir.rglob(
+                    f"{key['subject']}_session{key['session']}_params{key['paramset_idx']}_field{key['field_idx']}_motion_correction_results.pkl"
+                )
                 if f.is_file()
             ]
         )
@@ -447,7 +455,10 @@ class FieldSegmentation(dj.Computed):
             from caiman.source_extraction.cnmf.cnmf import CNMF, load_CNMF
             from caiman.source_extraction.cnmf.params import CNMFParams
 
-            mc_results = pickle.load(output_dir / f"{key['subject']}_session{key['session']}_params{key['paramset_idx']}_field{key['field_idx']}_motion_correction_results.pkl")
+            mc_results = pickle.load(
+                output_dir
+                / f"{key['subject']}_session{key['session']}_params{key['paramset_idx']}_field{key['field_idx']}_motion_correction_results.pkl"
+            )
             cnmf_mc_output_file = find_full_path(
                 processed_root_data_dir, extra_dj_params["cnmf_mc_output_file"]
             )

--- a/element_calcium_imaging/field_processing.py
+++ b/element_calcium_imaging/field_processing.py
@@ -2,6 +2,7 @@ import importlib
 import inspect
 import shutil
 import pathlib
+import pickle
 from collections.abc import Callable
 from datetime import datetime, timezone
 import re
@@ -371,8 +372,8 @@ class FieldMotionCorrection(dj.Computed):
             params["fnames"] = [
                 f.relative_to(processed_root_data_dir).as_posix() for f in file_paths
             ]
-            params["extra_dj_params"] = extra_dj_params
-
+            pickle.dump(extra_dj_params, output_dir / f"{key['subject']}_session{key['session']}_params{key['paramset_idx']}_field{key['field_idx']}_motion_correction_results.pkl")
+            
             if mc_indices is not None:
                 # store "indices" in params as tuple instead of the `slice` object
                 params["motion"]["indices"] = mc_indices
@@ -390,17 +391,18 @@ class FieldMotionCorrection(dj.Computed):
                 "mc_params": params,
             }
         )
-        # self.File.insert(
-        #     [
-        #         {
-        #             **key,
-        #             "file_name": f.relative_to(output_dir.parent).as_posix(),
-        #             "file": f,
-        #         }
-        #         for f in output_dir.rglob("*")
-        #         if f.is_file()
-        #     ]
-        # )
+
+        self.File.insert(
+            [
+                {
+                    **key,
+                    "file_name": f.relative_to(output_dir.parent).as_posix(),
+                    "file": f,
+                }
+                for f in output_dir.rglob(f"{key['subject']}_session{key['session']}_params{key['paramset_idx']}_field{key['field_idx']}_motion_correction_results.pkl")
+                if f.is_file()
+            ]
+        )
 
 
 @schema
@@ -445,7 +447,7 @@ class FieldSegmentation(dj.Computed):
             from caiman.source_extraction.cnmf.cnmf import CNMF, load_CNMF
             from caiman.source_extraction.cnmf.params import CNMFParams
 
-            mc_results = extra_dj_params.pop("mc_results", {})
+            mc_results = pickle.load(output_dir / f"{key['subject']}_session{key['session']}_params{key['paramset_idx']}_field{key['field_idx']}_motion_correction_results.pkl")
             cnmf_mc_output_file = find_full_path(
                 processed_root_data_dir, extra_dj_params["cnmf_mc_output_file"]
             )


### PR DESCRIPTION
In the PR, the `mc_params` object in `field_processing.MotionCorrection` is no longer placed into `params` and inserted into the database as a `longblob`. This will prevent the connection timeout error when inserting large objects into the database. Instead, the `mc_params` object is saved to the output directory as a `.pkl` object and loaded again the `field_processing.FieldSegmentation` step. A few considerations during review:

- Since `mc_params` is no longer a part of the `extra_dj_params` variable, do we now need to update the `uniqueness_dict` for memoized results in `FieldSegmentation`?
- When inserting into `field_processing.MotionCorrection.File`, is it okay to only save the `.pkl` at that step since that is the only file that will be directly relevant for the next step? We will be inserting all files in the outbox as `filepath@store` later when inserting into `imaging.Processing`. 